### PR TITLE
Transform keys to string on merge

### DIFF
--- a/lib/url.rb
+++ b/lib/url.rb
@@ -103,7 +103,7 @@ class URL
   end
 
   def merge(query)
-    self.query = self.query.merge(query)
+    self.query = self.query.merge(query.transform_keys(&:to_s))
 
     self
   end

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -86,6 +86,17 @@ class URLTest < Minitest::Test
       )
     end
 
+    it "merges a query with a symbol key" do
+      url = URL.parse("http://www.example.comi?foo=bar")
+
+      url.merge(foo: "baz", query: "string")
+
+      assert_equal(
+        {"foo" => "baz", "query" => "string"},
+        url.query
+      )
+    end
+
     it "returns self" do
       url = URL.parse("http://www.example.com")
 


### PR DESCRIPTION
Having to pass stringified keys to `merge` is annoying, as documented in #2. So this fixes that.