### PR TITLE
Deep transform keys in query hash to strings

### DIFF
--- a/lib/url.rb
+++ b/lib/url.rb
@@ -103,7 +103,7 @@ class URL
   end
 
   def merge(query)
-    self.query = self.query.merge(query.transform_keys(&:to_s))
+    self.query = self.query.merge(deep_transform_keys(query))
 
     self
   end
@@ -148,5 +148,12 @@ class URL
 
   def path_str
     Rack::Utils.escape_path(path) if path && !path.empty?
+  end
+
+  def deep_transform_keys(hash)
+    hash.each_with_object({}) do |(key, value), result|
+      result[key.to_s] =
+        value.is_a?(Hash) ? deep_transform_keys(value) : value
+    end
   end
 end

--- a/test/url_test.rb
+++ b/test/url_test.rb
@@ -89,10 +89,10 @@ class URLTest < Minitest::Test
     it "merges a query with a symbol key" do
       url = URL.parse("http://www.example.comi?foo=bar")
 
-      url.merge(foo: "baz", query: "string")
+      url.merge(foo: "baz", query: "string", deep: {key: "value"})
 
       assert_equal(
-        {"foo" => "baz", "query" => "string"},
+        {"foo" => "baz", "query" => "string", "deep" => {"key" => "value"}},
         url.query
       )
     end


### PR DESCRIPTION
The query params can be a multi-level hash, so we should deep transform the keys to strings.
